### PR TITLE
Add required workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ jobs:
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Adding the required workflow permission to avoid users getting blocked by an obscure publishing error. 

This was already patched [in the devcontainers/templates repo](https://github.com/devcontainers/templates/commit/71063d5a7ec286218163b7a5060c0da8944831d7#diff-762373f28dabfb9bf0baf6a4fb9d5ca47a3ff3a5c16c908e74b52d2eb81ddbc9R14)

Avoids the following kind of error:
```
[2024-08-27T15:39:21.061Z] https://ghcr.io/v2/devcontainers/template-starter/color/blobs/uploads/: Unexpected status code '403' 
{
    "errors": [
        {
            "code": "DENIED",
            "message": "installation not allowed to Create organization package"
        }
    ]
}
```