### PR TITLE
(ci): Copy entire test-utils folder

### DIFF
--- a/.github/actions/smoke-test/build.sh
+++ b/.github/actions/smoke-test/build.sh
@@ -43,7 +43,7 @@ if [ -d "${TEST_DIR}" ] ; then
     DEST_DIR="${SRC_DIR}/test-project"
     mkdir -p ${DEST_DIR}
     cp -Rp ${TEST_DIR}/* ${DEST_DIR}
-    cp test/test-utils/test-utils.sh ${DEST_DIR}
+    cp -Rp test/test-utils/* ${DEST_DIR}
 fi
 
 export DOCKER_BUILDKIT=1


### PR DESCRIPTION
This PR copies the entire test-utils folder so other files can be used while testing.

An example is in my templates repo where I test the EdgeDB connection for multiple templates: https://github.com/joshuanianji/devcontainer-templates/blob/main/test/test-utils/edgedb.sh