### PR TITLE
Fix <owner typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Templates are individually versioned by the `version` attribute in a Template's 
 
 Templates are source files packaged together that encode configuration for a complete development environment.
 
-This repo contains a GitHub Action [workflow](.github/workflows/release.yaml) that will publish each template to GHCR.  By default, each Template will be prefixed with the `<owner/<repo>` namespace.  For example, the two Templates in this repository can be referenced by an [implementing tool](https://containers.dev/supporting#tools) with:
+This repo contains a GitHub Action [workflow](.github/workflows/release.yaml) that will publish each template to GHCR.  By default, each Template will be prefixed with the `<owner>/<repo>` namespace.  For example, the two Templates in this repository can be referenced by an [implementing tool](https://containers.dev/supporting#tools) with:
 
 ```
 ghcr.io/devcontainers/template-starter/color:latest


### PR DESCRIPTION
Missing `>` character for the `<owner>` text